### PR TITLE
Update FastAPI endpoints in test_system

### DIFF
--- a/python_backend/test_system.py
+++ b/python_backend/test_system.py
@@ -226,10 +226,12 @@ async def test_fastapi_endpoints():
         
         # 这里只是示例，实际测试需要启动服务
         endpoints = [
-            "/",
-            "/status", 
-            "/tools",
-            "/shortcuts"
+            "/api/status",
+            "/api/tools",
+            "/api/tools/test",
+            "/api/config/{config_type}",
+            "/api/test",
+            "/dingtalk/webhook"
         ]
         
         logger.info(f"📋 API端点列表: {endpoints}")


### PR DESCRIPTION
## Summary
- fix API endpoint list in `test_system.py` to use `/api/*` paths

## Testing
- `python -m py_compile python_backend/test_system.py`

------
https://chatgpt.com/codex/tasks/task_e_6863b870e5e8832a88c1cb7441ecb3bd